### PR TITLE
fix-markingstory-as-read

### DIFF
--- a/src/components/Constants.ts
+++ b/src/components/Constants.ts
@@ -8,9 +8,11 @@ export const APP_VERSION = process.env.APP_VERSION;
 export const UNSUPPORTED_ORIENTATION_ALERT_MESSAGE =
   "The digital guide is best viewed in Portrait mode.";
 export const ART_WORK_INFO_URL = "/api/artwork/";
-export const STORIES_URL = (artworkId) => `/api/artwork/${artworkId}/stories`;
+export const STORIES_URL = (artworkId: string) =>
+  `/api/artwork/${artworkId}/stories`;
 export const STORIES_EMAIL_PAGE_URL = "/api/stories/";
-export const STORIES_READ_URL = "/api/snaps/mark_story_as_read?image_id=";
+export const STORIES_READ_URL = (artworkId: string, storyId: string) =>
+  `/api/artwork/${artworkId}/stories/${storyId}/read`;
 export const STORE_SEARCHED_RESULT_URL = "/api/snaps/storeSearchedResult";
 export const SUBMIT_BOOKMARKS_EMAIL_URL = "/api/bookmarks";
 export const SAVE_LANGUAGE_PREFERENCE_URL = "/api/bookmarks/set_language";

--- a/src/services/SearchRequestService.ts
+++ b/src/services/SearchRequestService.ts
@@ -103,10 +103,10 @@ class SearchRequestService {
     }
   };
 
-  markStoryAsRead = async (imageId, storyId) => {
+  markStoryAsRead = async (imageId: string, storyId: string) => {
     try {
       let response = await axios.post(
-        constants.STORIES_READ_URL + imageId + "&unique_identifier=" + storyId
+        constants.STORIES_READ_URL(imageId, storyId)
       );
       return response.data;
     } catch (error) {


### PR DESCRIPTION
This pull request just corrects the route the frontend uses to mark a story as read, as the corresponding route on the backend has changed to be more RESTful. Confirmed this works as expected.