### PR TITLE
remove-UNSAFE__-prepends

### DIFF
--- a/src/components/Artwork.tsx
+++ b/src/components/Artwork.tsx
@@ -180,7 +180,7 @@ class Artwork extends Component {
     return { artwork, roomRecords };
   };
 
-  async UNSAFE_componentWillMount() {
+  async componentWillMount() {
     let imageId = this.state.result
       ? this.state.result.data.records[0].id
       : this.props.match.params.imageId;

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -40,7 +40,7 @@ class HomeComponent extends Component {
     };
   }
 
-  UNSAFE_componentWillMount() {
+  componentWillMount() {
     resetApplication();
   }
 

--- a/src/components/SnapResult.tsx
+++ b/src/components/SnapResult.tsx
@@ -162,7 +162,7 @@ class SnapResults extends Component {
     }
   };
 
-  async UNSAFE_componentWillMount() {
+  async componentWillMount() {
     console.log("SnapResults >> componentWillMount");
     let imageId = this.props.match.params.imageId;
     if (this.state.result) {

--- a/src/components/StoryItem.tsx
+++ b/src/components/StoryItem.tsx
@@ -46,7 +46,7 @@ class StoryItem extends React.Component {
     this.overlayTimelineGSAP = this.overlayTimeline.getGSAP();
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps(nextProps) {
     // Handles marking this story as being read by the user
     if (nextProps.sceneStatus.type === "start" && nextProps.storyIndex === 2) {
       if (!this.state.storyRead) {

--- a/src/components/StoryPage.tsx
+++ b/src/components/StoryPage.tsx
@@ -49,7 +49,7 @@ class StoryPage extends Component {
     };
   }
 
-  async UNSAFE_componentWillMount() {
+  async componentWillMount() {
     const slug = this.props.match.params.slug;
     const queryParams = queryString.parse(this.props.location.search);
 

--- a/src/components/withTranslation.tsx
+++ b/src/components/withTranslation.tsx
@@ -14,7 +14,7 @@ const withTranslation = (WrappedComponent) => {
       };
     }
 
-    async UNSAFE_componentWillMount() {
+    async componentWillMount() {
       console.log(
         "WithTranslation >> componentWillMount. Load the translations here"
       );


### PR DESCRIPTION
I ran a code mod to prepend `UNSAFE__` to the React lifecycle methods when I attempted the upgrade to React 18. Since I downgraded back to React 15/16 these were not necessary.