### PR TITLE
FOC-38-make-file-updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,13 +35,23 @@ dry_package:
 	npx serverless package --stage dry
 
 # Deploy to development
-deploy_dev: build dev reset_node
+deploy_dev: set_env_dev build dev reset_node
 
 # Deploy to production
-deploy_prod: build prod reset_node
+deploy_prod: set_env_prod build prod reset_node
 
 # Test building deployment package
 deploy_dry: build dry_package reset_node
+
+# Set PUBLIC_URL for development
+# TODO - Try to pull this from the environment instead of hard-coding here
+# TODO - Sync built assets from `build` folder to the `build` directory in the S3 bucket
+set_env_dev: 
+	export PUBLIC_URL="https://focus-application-dev-serverlessdeploymentbucket-wyfkuk6n7ves.s3.amazonaws.com/build"
+
+# Set PUBLIC_URL for production
+set_env_prod: 
+	export PUBLIC_URL="https://focus-application-dev-serverlessdeploymentbucket-wyfkuk6n7ves.s3.amazonaws.com/build"
 
 ######################################
 #


### PR DESCRIPTION
I added a new step to our makefile commands for the development and production stages.

This sets the `PUBLIC_URL` environment variable prior to building the React assets, so that all asset paths are built with the `PUBLIC_URL` prepended to them.

This allows us to not have to do anything special for local development like we do a bit in Barnes Live [like here](https://github.com/BarnesFoundation/barnes-video-chatter/blob/2a5beeda0577a472d410d78ba78e9761e713d2ec/src/components/app/videoStreamModule/videoStreamModule.tsx#L19). 

Instead, all we have to do after building the asset bundle is upload it to the S3 at the directory we specify in the PUBLIC_URL value. I'm going to automate this in a later ticket, as part of the makefile commands too.

This also means the Lambda deployment doesn't get pinged/requested for _any_ React related assets! Which means
- We save a bit on Lambda invocation charges
- Lessens the amounts of requests being routed to Lambda, since now React will call to the S3 bucket for its assets

It also means we can remove the `build` folder from the AWS Lambda deployment bundle, but we'll save that for a later ticket.

CC @lpassamano @livsteinmetz I'm curious where assets are being stored for the LXP deployment and how we're referencing them during local development. We can eventually do this same step for our other apps, if we aren't already!