### PR TITLE
Bugfix -- stories emails

### DIFF
--- a/server/api/controllers/storyController.ts
+++ b/server/api/controllers/storyController.ts
@@ -11,7 +11,7 @@ class StoryController {
   ) {
     const storyTitleSlug = request.params.storyTitleSlug;
     const languagePreference =
-      request.query.lang.toString() || request.session.lang_pref || "en";
+      request.query.lang?.toString() || request.session.lang_pref || "en";
 
     const foundStory = await prisma.stories.findFirst({
       where: {


### PR DESCRIPTION
## Description
The bug was caused by missing "lang" query param, which then caused a type error when we tried to convert it into a string! I added in the TS optional indicator, which should prevent this issue!

Error log for reference:
![image](https://user-images.githubusercontent.com/26989990/195172104-33f60894-4076-4ee2-965e-e91df8ec9714.png)