### PR TITLE
Bugfix -- Hygraph error

### DIFF
--- a/server/api/services/graphCMSService/graphCMSService.ts
+++ b/server/api/services/graphCMSService/graphCMSService.ts
@@ -181,11 +181,11 @@ export default class GraphCMSService {
     } = await GraphCMSService.makeGraphQLRequest(query);
 
     // Check these two parts of the response for the story
-    const retrievedStory = storiesForObjectIds[0]?.relatedStories;
     const storyInformation = { storyId: null, hasStory: false };
+    const retrievedStory = storiesForObjectIds[0]?.relatedStories;
 
-    if (retrievedStory) {
-      storyInformation.storyId = retrievedStory[0].id;
+    if (retrievedStory && retrievedStory.length) {
+      storyInformation.storyId = retrievedStory[0]?.id;
       storyInformation.hasStory = true;
     }
 


### PR DESCRIPTION
Some Hygraph searches don't return any results, which was then causing a type error when we tried to access items inside the expected result. This can be tested with any Barnes collection object that does not have curatorial content or a story, here are some test examples:
http://localhost:3006/artwork/7005
http://localhost:3006/artwork/4760