### PR TITLE
image-upload-tweaks

### DIFF
--- a/server/api/jobs/imageUploadJob.ts
+++ b/server/api/jobs/imageUploadJob.ts
@@ -58,7 +58,12 @@ class ImageUploadJob {
         },
       });
 
-      console.debug(`Successfully created photo record for ${photoIdentifier}`);
+      const queryEndTime = Date.now();
+      const elapsedSeconds = (queryEndTime - queryStartTime) / 1000;
+
+      console.debug(
+        `Successfully created photo record for ${photoIdentifier} after ${elapsedSeconds} seconds from query start`
+      );
     } catch (error) {
       const queryEndTime = Date.now();
       const elapsedSeconds = (queryEndTime - queryStartTime) / 1000;


### PR DESCRIPTION
We're still getting errors occasionally when our upload to S3 runs, which is indicating some sort of timeout or like no data is being sent through the S3 upload command. I've added the length of the buffer in case it helps.

We have greatly reduced the number of times [a photo record fails to create](https://github.com/BarnesFoundation/Focus-3.0/compare/image-upload-tweaks?expand=1#diff-897f84d50845e67fc07a403672605e33959cdb25cda60ee12b921aaf3162c701R67). I checked and this past weekend of the Modigliani Exhibition, we only encountered this error twice! Compared to tens of times prior to some fixes.

However, I have a feeling that the roundtrip of executing a query from our Lambda, and the time to receive any sort of response from the database server, is the root cause of this issue. I've added some time logging to check how long our query for the photo record creation is taking to see if this helps us identify this as the cause.