### PR TITLE
Remove unused route and controller fn

### DIFF
--- a/server/api/controllers/artworkController.ts
+++ b/server/api/controllers/artworkController.ts
@@ -146,41 +146,6 @@ class ArtworkController {
       });
     }
   }
-
-  public static async getSpecialExhibitionObject(
-    request: express.Request,
-    response: express.Response
-  ) {
-    const objectId = request.params.objectId;
-
-    // TODO - uncomment this once translation is working
-    // const session = request.session;
-    // const languagePreference = session.lang_pref;
-    const objectData = await ArtworkService.findSpecialExhibitionObject(
-      objectId
-    );
-
-    // Manipulate the data to have save key/pairs as the ES results
-    objectData[0]["art_url"] = objectData[0].image.url;
-    objectData[0]["shortDescription"] = objectData[0].shortDescription.html;
-    objectData[0]["id"] = objectData[0].objectId;
-
-    const responseObject = {
-      data: {
-        records: objectData,
-        roomRecords: null,
-        message: "Result found",
-        // TODO: Implement stories for special exhibition objects
-        // showStory: storyInformation.hasStory,
-        showStory: false,
-        specialExhibition: true,
-      },
-      success: true,
-      requestComplete: true,
-    };
-
-    return response.status(200).json(responseObject);
-  }
 }
 
 export default ArtworkController;

--- a/server/api/routes/artworkRouter.ts
+++ b/server/api/routes/artworkRouter.ts
@@ -15,9 +15,5 @@ ArtworkRouter.post(
   "/:artworkId/stories/:storyId/read",
   ArtworkController.markStoryAsRead
 );
-ArtworkRouter.get(
-  "/special-exhibition/:objectId",
-  ArtworkController.getSpecialExhibitionObject
-);
 
 export default ArtworkRouter;


### PR DESCRIPTION
## Description
A quick PR for some clean up -- when doing some other work I noticed that this route and controller fn were not deleted after the functionality was moved into the [ExhibitionRouter](https://github.com/BarnesFoundation/Focus-3.0/blob/development/server/api/routes/exhibitionRouter.ts) and [ExhibitionController](https://github.com/BarnesFoundation/Focus-3.0/blob/e072f8162ac66968c3c294bcb1206d940bdf47dd/server/api/controllers/exhibitionController.ts#L8-L58).