### PR TITLE
fix-api-utils-import

### DIFF
--- a/server/api/controllers/artworkController.ts
+++ b/server/api/controllers/artworkController.ts
@@ -1,4 +1,4 @@
-import { getPreferredLanguage } from "api/utils";
+import { getPreferredLanguage } from "../utils";
 import express from "express";
 
 import {

--- a/server/api/controllers/exhibitionController.ts
+++ b/server/api/controllers/exhibitionController.ts
@@ -1,4 +1,4 @@
-import { getPreferredLanguage } from "api/utils";
+import { getPreferredLanguage } from "../utils";
 import express from "express";
 
 import { ArtworkService, TranslateService } from "../services";

--- a/server/api/controllers/translationController.ts
+++ b/server/api/controllers/translationController.ts
@@ -1,4 +1,4 @@
-import { getPreferredLanguage } from "api/utils";
+import { getPreferredLanguage } from "../utils";
 import express from "express";
 
 import { TranslateService } from "../services";


### PR DESCRIPTION
Doing imports from an absolute path like below
```
import { getPreferredLanguage } from "api/utils";
```
doesn't work since we don't have absolute paths configured with our tsconfig.json. This caused the servers to crash so changing back to relative imports.