### PR TITLE
FOC-63 maybe the squished image is fixed

### DIFF
--- a/src/components/Camera.tsx
+++ b/src/components/Camera.tsx
@@ -120,7 +120,7 @@ export class CameraComponent extends Component<CameraProps, CameraState> {
       const videoStream = await navigator.mediaDevices.getUserMedia({
         video: {
           facingMode: this.state.frontCamera ? "user" : "environment",
-          width: 1920,
+          width: 1080,
           height: 1080,
         },
       });


### PR DESCRIPTION
## **Description**
This seems like to simple a fix for the squished video issue but I tested this with ngrok through my 2020 iphone se (which had the squished issue in the Barnes on Monday) also still works with with an Android phone.  All I did was set the video stream to be a 1:1 ratio rather than a 1.8:1.  This seems like too simple a solution, I'm not the most familiar with the code base, does anyone know the reasoning for the original aspect ratio?

## **Jira**
[Link to Jira ticket](https://barnesfoundation.atlassian.net/browse/FOC-63)

## **Todo**
testing...
 
 ## **Screenshots**
![image](https://user-images.githubusercontent.com/41017778/207937828-672df0dd-c5cc-4848-b1f7-7622fd48a8ef.png)
![image](https://user-images.githubusercontent.com/41017778/207937868-fa116f91-0e60-4778-b5a7-fa9c0d634cac.png)
