### PR TITLE
FOC-74 -- Save special exhibition objects in the database

### DIFF
--- a/server/api/middleware/captureScannedHistoryMiddleware.ts
+++ b/server/api/middleware/captureScannedHistoryMiddleware.ts
@@ -10,7 +10,10 @@ export const captureScannedHistoryMiddleware = async (
   next: express.NextFunction
 ) => {
   if (request.session.initialized) {
+    // Artwork id is passed for Barnes collection objects
     const artworkId = request.params.artworkId;
+    // Object id is passed for special exhibition objects
+    const objectId = request.params.objectId;
     const sessionId = request.sessionID;
 
     // Add the artwork id to the existing scanned history
@@ -27,14 +30,16 @@ export const captureScannedHistoryMiddleware = async (
 
     // Generate a new bookmark record for this artwork
     const now = new Date(Date.now()).toISOString();
+    // Set email_sent as true for special exhibition objects because we do not want to include them in the bookmark email
     await prisma.bookmarks.create({
       data: {
         session_id: sessionId,
-        image_id: artworkId,
+        image_id: objectId ? objectId : artworkId,
         created_at: now,
         updated_at: now,
         email: bookmarkThatHasEmail ? bookmarkThatHasEmail.email : undefined,
         language: request.session.lang_pref,
+        mail_sent: objectId ? true : false,
       },
     });
   }

--- a/server/api/routes/exhibitionRouter.ts
+++ b/server/api/routes/exhibitionRouter.ts
@@ -1,9 +1,14 @@
 import { Router } from "express";
 
 import { ExhibitionController } from "../controllers";
+import { captureScannedHistoryMiddleware } from "../middleware";
 
 const ExhibitionRouter = Router();
 
-ExhibitionRouter.get("/:objectId", ExhibitionController.getObjectInfo);
+ExhibitionRouter.get(
+  "/:objectId",
+  captureScannedHistoryMiddleware,
+  ExhibitionController.getObjectInfo
+);
 
 export default ExhibitionRouter;


### PR DESCRIPTION
## Description
Recently we noticed that we were not saving the special exhibition scans to the database, but we should be so we can have that data later!

To do this I added the CaptureScannedHistoryMiddleware to the `/exhibition/:objectId` endpoint. I made a few updates to the middleware to work with the special exhibition objects: 
- use either the artworkId or the objectId from the params as the `image_id` in the db
- set `mail_sent` to true for special exhibition objects -- this is because I noticed that when we query the db for the bookmarks for the email job [we are only including bookmarks where `mail_sent = false`](https://github.com/BarnesFoundation/Focus-3.0/blob/c06d185c6f6b90a0a8b66ede47ac166466eb3f17/server/api/jobs/bookmarkDeliveryJob.ts#L115-L123), so by setting `mail_sent` to true I am hoping that they will not be included in the bookmark emails.