### PR TITLE
Focus ios error logic rework in home component

### DIFF
--- a/src/components/ArtworkWithStory.tsx
+++ b/src/components/ArtworkWithStory.tsx
@@ -380,8 +380,9 @@ export class ArtworkWithStory extends Component<
     const { stories, storyTitle } = this.state;
     const { showEmailForm } = this.props;
 
-    // Iterate through the available stories
-    return stories.map((story, index) => {
+    // Iterate through the available stories, removing any that don't include details
+    const storiesWithDetails = stories.filter((story) => story.detail);
+    return storiesWithDetails.map((story, index) => {
       const storyIndex = index + 1;
       const storyDuration = this.state.storyDurationsCurrent[index] * 5;
       const storySceneOffset =
@@ -403,7 +404,7 @@ export class ArtworkWithStory extends Component<
 
       // When email form is not visible, set padding botttom to 200px on the last story card
       const emailCapturedBottomStyle =
-        stories.length === index + 1 && !showEmailForm
+        storiesWithDetails.length === index + 1 && !showEmailForm
           ? { paddingBottom: `200px` }
           : { paddingBottom: `0` };
 
@@ -448,7 +449,9 @@ export class ArtworkWithStory extends Component<
                   progress={progress}
                   sceneStatus={event}
                   storyIndex={index}
-                  isLastStoryItem={index === stories.length - 1 ? true : false}
+                  isLastStoryItem={
+                    index === storiesWithDetails.length - 1 ? true : false
+                  }
                   story={story}
                   storyTitle={storyTitle}
                   selectedLanguage={this.props.selectedLanguage}

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -59,19 +59,15 @@ export const HomeComponent: React.FC<WithTranslationState> = ({
 
   /** Determines if navigator.mediaDevices.getUserMedia() is available on the current iOS device */
   const checkForGetUserMedia = () => {
-    const iOSVersion = parseFloat(osVersion);
-
     // navigator.mediaDevices.getUserMedia() is only supported on iOS > 11.0 and only on Safari (not Chrome, Firefox, etc.)
-    if (iOSVersion >= parseFloat("11.0")) {
-      if (!isSafari && !isChrome && !isFirefox) {
-        setUnsupportedIOSBrowser(true);
-        setShowError(true);
-      }
-    }
-
-    // If they're not on iOS 11, it doesn't matter what browser they're using, navigator.mediaDevices.getUserMedia() will return undefined
-    else {
+    // at some point in 2022 not sure the version it became available for other browsers
+    const supportedIOS = navigator.mediaDevices.getUserMedia();
+    if (supportedIOS === undefined) {
       setUnsupportedIOSVersion(true);
+      setShowError(true);
+    }
+    if (!isSafari && !isChrome && !isFirefox) {
+      setUnsupportedIOSBrowser(true);
       setShowError(true);
     }
   };

--- a/src/components/StoryItem.tsx
+++ b/src/components/StoryItem.tsx
@@ -245,18 +245,22 @@ class StoryItem extends React.Component<StoryItemProps, StoryItemState> {
 
   /** Generates the url for retrieving the artwork with transformation parameters */
   getArtUrl = () => {
-    return `${this.props.story.detail.art_url}?crop=faces,entropy&fit=crop&w=${screen.width}&h=${screen.height}`;
+    return `${this.props.story.detail?.art_url}?crop=faces,entropy&fit=crop&w=${screen.width}&h=${screen.height}`;
   };
 
   /** Returns boolean whether or not the artist is unidentified */
   isUnidentifiedArtist = () => {
-    return this.props.story.detail.people
+    return this.props.story.detail?.people
       .toLowerCase()
       .includes("unidentified");
   };
 
   /** Generates the aria-label for the background image */
   generateImageAriaLabel = () => {
+    if (!this.props.story.detail) {
+      return "";
+    }
+
     const { title, people, culture } = this.props.story.detail;
     return `${title} by ${people}${
       this.isUnidentifiedArtist() ? `, ${culture}` : ""


### PR DESCRIPTION
![image](https://github.com/BarnesFoundation/Focus-3.0/assets/41017778/9f8fc457-2148-4d22-80a7-708d3df2b523)
Latest IOS update on certain phones is for some reason breaking the react-device-detect IOS version check. Since the check ultimately just wants to know if the getUserMedia() function is available then we can just check for that and if it is undefined then that throws the ios error