### PR TITLE
Focus ios error logic rework in home component

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -59,19 +59,15 @@ export const HomeComponent: React.FC<WithTranslationState> = ({
 
   /** Determines if navigator.mediaDevices.getUserMedia() is available on the current iOS device */
   const checkForGetUserMedia = () => {
-    const iOSVersion = parseFloat(osVersion);
-
     // navigator.mediaDevices.getUserMedia() is only supported on iOS > 11.0 and only on Safari (not Chrome, Firefox, etc.)
-    if (iOSVersion >= parseFloat("11.0")) {
-      if (!isSafari && !isChrome && !isFirefox) {
-        setUnsupportedIOSBrowser(true);
-        setShowError(true);
-      }
-    }
-
-    // If they're not on iOS 11, it doesn't matter what browser they're using, navigator.mediaDevices.getUserMedia() will return undefined
-    else {
+    // at some point in 2022 not sure the version it became available for other browsers
+    const supportedIOS = navigator.mediaDevices.getUserMedia();
+    if (supportedIOS === undefined) {
       setUnsupportedIOSVersion(true);
+      setShowError(true);
+    }
+    if (!isSafari && !isChrome && !isFirefox) {
+      setUnsupportedIOSBrowser(true);
       setShowError(true);
     }
   };


### PR DESCRIPTION
![image](https://github.com/BarnesFoundation/Focus-3.0/assets/41017778/a3aa867a-0ba1-4661-8204-c18344d993dd)
For some reason or another the latest ios update broke the logic that was checking for ios version to know if getUserMedia was available. This simplifies the check to just locate the function we need and if it isn't there then throw the error